### PR TITLE
Work around unicode confusion on python2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,17 @@
 # Changes
 
+## v1.2.2 (?)
+
+### Documentation
+
+- Enhance readme to clarify why the project is built the way it is.
+  #4, @dwt
+
+### Bug fixes
+
+- Fix a python 2 issue on centos 7, where traditional chinese
+  in filenames tripped up python 2's `os.listdir()`. #5, @dwt
+
 ## v1.2.1 (2022-03-12)
 
 ### Documentation

--- a/CHANGES
+++ b/CHANGES
@@ -2,7 +2,7 @@
 
 ## v1.2.1 (2022-03-12)
 
-## Documentation
+### Documentation
 
 ### Packaging
 


### PR DESCRIPTION
Work around an exception where on centos 7 python 2 will get type confused for filenames containing traditional chinese characters.

I just spent way too much time debugging a weird python 2 edgecase. I know. But at least this seems to work for all python versions I tested this, up to python 3.12.